### PR TITLE
Add Go import comments.

### DIFF
--- a/bytes.v7/doc.go
+++ b/bytes.v7/doc.go
@@ -30,5 +30,4 @@ NewBuffer 创建一个可随机读写的内存文件，支持 ReadAt/WriteAt 方
 	n, err := b.ReadAt(slice, 0)
 	...
 */
-package bytes
-
+package bytes // import "qiniupkg.com/x/bytes.v7"

--- a/bytes.v7/seekable/seekable.go
+++ b/bytes.v7/seekable/seekable.go
@@ -1,5 +1,5 @@
 // This package provide a method to read and replace http.Request's body.
-package seekable
+package seekable // import "qiniupkg.com/x/bytes.v7/seekable"
 
 import (
 	"errors"

--- a/cmdline.v7/cmdline.go
+++ b/cmdline.v7/cmdline.go
@@ -1,4 +1,4 @@
-package cmdline
+package cmdline // import "qiniupkg.com/x/cmdline.v7"
 
 import (
 	"errors"
@@ -45,12 +45,12 @@ equal $(code1) 200
 // -------------------------------------------------------------------------*/
 
 var (
-	EOF = errors.New("end of file")
-	ErrUnsupportedFeatureSubCmd = errors.New("unsupported feature: sub command")
-	ErrUnsupportedFeatureMultiCmds = errors.New("unsupported feature: multi commands")
-	ErrInvalidEscapeChar = errors.New("invalid escape char")
-	ErrIncompleteStringExpectQuot = errors.New("incomplete string, expect \"")
-	ErrIncompleteStringExpectSquot = errors.New("incomplete string, expect '")
+	EOF                               = errors.New("end of file")
+	ErrUnsupportedFeatureSubCmd       = errors.New("unsupported feature: sub command")
+	ErrUnsupportedFeatureMultiCmds    = errors.New("unsupported feature: multi commands")
+	ErrInvalidEscapeChar              = errors.New("invalid escape char")
+	ErrIncompleteStringExpectQuot     = errors.New("incomplete string, expect \"")
+	ErrIncompleteStringExpectSquot    = errors.New("incomplete string, expect '")
 	ErrIncompleteStringExpectBacktick = errors.New("incomplete string, expect ` or |")
 )
 
@@ -108,7 +108,7 @@ func NewParser() *Parser {
 
 	return &Parser{
 		ExecSub: defaultExecSub,
-		Escape: defaultEscape,
+		Escape:  defaultEscape,
 	}
 }
 
@@ -125,8 +125,8 @@ const (
 )
 
 const (
-	endMask_QuotString = RDIV | BACKTICK | OR | QUOT			// [\\`|"]
-	endMask_NonquotString = RDIV | BACKTICK | OR | blankAndEOLs	// [\\`| \t\r\n;]
+	endMask_QuotString    = RDIV | BACKTICK | OR | QUOT         // [\\`|"]
+	endMask_NonquotString = RDIV | BACKTICK | OR | blankAndEOLs // [\\`| \t\r\n;]
 )
 
 func (p *Parser) parseString(
@@ -174,7 +174,7 @@ func (p *Parser) parseString(
 			}
 			codeNext = codeNext[len+1:]
 		case '"':
-			ok = true			
+			ok = true
 			codeNext = codeNext[n+1:]
 			return
 		default:
@@ -184,7 +184,7 @@ func (p *Parser) parseString(
 			codeNext = codeNext[n+1:]
 			return
 		}
-		ok = true			
+		ok = true
 	}
 	return
 }
@@ -261,4 +261,3 @@ func (p *Parser) ParseCode(code string) (cmd []string, codeNext string, err erro
 }
 
 // ---------------------------------------------------------------------------
-

--- a/config.v7/load_conf.go
+++ b/config.v7/load_conf.go
@@ -1,4 +1,4 @@
-package config
+package config // import "qiniupkg.com/x/config.v7"
 
 import (
 	"bytes"
@@ -106,11 +106,10 @@ func trimCommentsLine(line []byte) []byte {
 		case '"':
 			quoteCount++
 		case '#':
-			if (quoteCount&1) == 0 {
+			if (quoteCount & 1) == 0 {
 				return line[:i]
 			}
 		}
 	}
 	return line
 }
-

--- a/ctype.v7/ctype.go
+++ b/ctype.v7/ctype.go
@@ -1,4 +1,4 @@
-package ctype
+package ctype // import "qiniupkg.com/x/ctype.v7"
 
 const (
 	UPPER     = 0x01       /* upper case letter[A-Z] */

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-package x
+package x // import "qiniupkg.com/x"
 
 import (
 	_ "qiniupkg.com/x/bytes.v7"
@@ -6,4 +6,3 @@ import (
 	_ "qiniupkg.com/x/rpc.v7"
 	_ "qiniupkg.com/x/url.v7"
 )
-

--- a/errors.v7/error_info.go
+++ b/errors.v7/error_info.go
@@ -1,4 +1,4 @@
-package errors
+package errors // import "qiniupkg.com/x/errors.v7"
 
 import (
 	"errors"
@@ -61,10 +61,10 @@ func Err(err error) error {
 // --------------------------------------------------------------------
 
 type ErrorInfo struct {
-	err  error
-	why  error
-	cmd  []interface{}
-	pc   uintptr
+	err error
+	why error
+	cmd []interface{}
+	pc  uintptr
 }
 
 func shortFile(file string) string {
@@ -84,7 +84,7 @@ func Info(err error, cmd ...interface{}) *ErrorInfo {
 }
 
 func InfoEx(calldepth int, err error, cmd ...interface{}) *ErrorInfo {
-	pc, _, _, ok := runtime.Caller(calldepth+1)
+	pc, _, _, ok := runtime.Caller(calldepth + 1)
 	if !ok {
 		pc = 0
 	}

--- a/jsonutil.v7/unmarshal_string.go
+++ b/jsonutil.v7/unmarshal_string.go
@@ -1,4 +1,4 @@
-package jsonutil
+package jsonutil // import "qiniupkg.com/x/jsonutil.v7"
 
 import (
 	"encoding/json"
@@ -11,9 +11,8 @@ import (
 func Unmarshal(data string, v interface{}) error {
 
 	sh := *(*reflect.StringHeader)(unsafe.Pointer(&data))
-	arr := (*[1<<30]byte)(unsafe.Pointer(sh.Data))
+	arr := (*[1 << 30]byte)(unsafe.Pointer(sh.Data))
 	return json.Unmarshal(arr[:sh.Len], v)
 }
 
 // ----------------------------------------------------------
-

--- a/log.v7/logext.go
+++ b/log.v7/logext.go
@@ -1,4 +1,4 @@
-package log
+package log // import "qiniupkg.com/x/log.v7"
 
 import (
 	"bytes"
@@ -51,10 +51,10 @@ var levels = []string{
 // the Writer's Write method.  A Logger can be used simultaneously from
 // multiple goroutines; it guarantees to serialize access to the Writer.
 type Logger struct {
-	mu         sync.Mutex // ensures atomic writes; protects the following fields
-	prefix     string     // prefix to write at beginning of each line
-	flag       int        // properties
-	Level      int        // debug level
+	mu         sync.Mutex   // ensures atomic writes; protects the following fields
+	prefix     string       // prefix to write at beginning of each line
+	flag       int          // properties
+	Level      int          // debug level
 	out        io.Writer    // destination for output
 	buf        bytes.Buffer // for accumulating text to write
 	levelStats [6]int64

--- a/mockhttp.v7/mockhttp.go
+++ b/mockhttp.v7/mockhttp.go
@@ -1,4 +1,4 @@
-package mockhttp
+package mockhttp // import "qiniupkg.com/x/mockhttp.v7"
 
 import (
 	"errors"

--- a/reqid.v7/reqid.go
+++ b/reqid.v7/reqid.go
@@ -1,8 +1,8 @@
-package reqid
+package reqid // import "qiniupkg.com/x/reqid.v7"
 
 import (
-	"encoding/binary"
 	"encoding/base64"
+	"encoding/binary"
 	"net/http"
 	"time"
 
@@ -49,4 +49,3 @@ func FromContext(ctx Context) (reqid string, ok bool) {
 }
 
 // --------------------------------------------------------------------
-

--- a/rpc.v7/gob/gobrpc_client.go
+++ b/rpc.v7/gob/gobrpc_client.go
@@ -1,4 +1,4 @@
-package gob
+package gob // import "qiniupkg.com/x/rpc.v7/gob"
 
 import (
 	"bytes"
@@ -104,4 +104,3 @@ func (r Client) CallWithGob(
 }
 
 // ---------------------------------------------------------------------------
-

--- a/rpc.v7/rpc_client.go
+++ b/rpc.v7/rpc_client.go
@@ -1,4 +1,4 @@
-package rpc
+package rpc // import "qiniupkg.com/x/rpc.v7"
 
 import (
 	"bytes"
@@ -106,7 +106,7 @@ func (r Client) DoRequestWithForm(
 		} else {
 			url1 += "?"
 		}
-		return r.DoRequest(ctx, method, url1 + msg)
+		return r.DoRequest(ctx, method, url1+msg)
 	}
 	return r.DoRequestWith(
 		ctx, method, url1, "application/x-www-form-urlencoded", strings.NewReader(msg), len(msg))
@@ -341,4 +341,3 @@ func getRequestCanceler(tp http.RoundTripper) (rc requestCanceler, ok bool) {
 }
 
 // --------------------------------------------------------------------
-

--- a/ts.v7/testing.go
+++ b/ts.v7/testing.go
@@ -1,4 +1,4 @@
-package ts
+package ts // import "qiniupkg.com/x/ts.v7"
 
 import (
 	"fmt"

--- a/url.v7/urlescape.go
+++ b/url.v7/urlescape.go
@@ -1,4 +1,4 @@
-package url
+package url // import "qiniupkg.com/x/url.v7"
 
 import (
 	"strconv"

--- a/xlog.v7/xlog.go
+++ b/xlog.v7/xlog.go
@@ -1,4 +1,4 @@
-package xlog
+package xlog // import "qiniupkg.com/x/xlog.v7"
 
 import (
 	"fmt"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
