### PR TITLE
feat(log): make Lmodule option as deprecated and add  Lintermediatefile model to enhance log library

### DIFF
--- a/log/logext.go
+++ b/log/logext.go
@@ -19,13 +19,15 @@ const (
 	// order they appear (the order listed here) or the format they present (as
 	// described in the comments).  A colon appears after these items:
 	//	2009/0123 01:23:23.123123 /a/b/c/d.go:23: message
-	Ldate             = 1 << iota                     // the date: 2009/0123
-	Ltime                                             // the time: 01:23:23
-	Lmicroseconds                                     // microsecond resolution: 01:23:23.123123.  assumes Ltime.
-	Llongfile                                         // full file name and line number: /a/b/c/d.go:23
-	Lshortfile                                        // final file name element and line number: d.go:23. overrides Llongfile
-	Lintermediatefile                                 // final file format output is typically in the format c/d.go:23, which includes the last two paths. If the compilation includes the '-trimpath' parameter, this format will just exclude the module path prefix.
+	Ldate         = 1 << iota // the date: 2009/0123
+	Ltime                     // the time: 01:23:23
+	Lmicroseconds             // microsecond resolution: 01:23:23.123123.  assumes Ltime.
+	Llongfile                 // full file name and line number: /a/b/c/d.go:23
+	Lshortfile                // final file name element and line number: d.go:23. overrides Llongfile
+	// Deprecated: recommend to use Lintermediatefile option instead.
+	Lmodule                                           // module name
 	Llevel                                            // level: 0(Debug), 1(Info), 2(Warn), 3(Error), 4(Panic), 5(Fatal)
+	Lintermediatefile                                 // final file format output is typically in the format c/d.go:23, which includes the last two paths. If the compilation includes the '-trimpath' parameter, this format will just exclude the module path prefix.
 	LstdFlags         = Ldate | Ltime | Lmicroseconds // initial values for the standard logger
 	Ldefault          = Llevel | Lintermediatefile | LstdFlags
 ) // [prefix][time][level][shortfile|longfile|intermediatefile]: message

--- a/log/logext.go
+++ b/log/logext.go
@@ -22,11 +22,10 @@ const (
 	Lmicroseconds                                 // microsecond resolution: 01:23:23.123123.  assumes Ltime.
 	Llongfile                                     // full file name and line number: /a/b/c/d.go:23
 	Lshortfile                                    // final file name element and line number: d.go:23. overrides Llongfile
-	Lmodule                                       // module name
 	Llevel                                        // level: 0(Debug), 1(Info), 2(Warn), 3(Error), 4(Panic), 5(Fatal)
 	LstdFlags     = Ldate | Ltime | Lmicroseconds // initial values for the standard logger
-	Ldefault      = Lmodule | Llevel | Lshortfile | LstdFlags
-) // [prefix][time][level][module][shortfile|longfile]
+	Ldefault      = Llevel | Lshortfile | LstdFlags
+) // [prefix][time][level][shortfile|longfile]
 
 const (
 	// Ldebug is a log output level that prints debug information.
@@ -104,9 +103,6 @@ func itoa(buf *bytes.Buffer, i int, wid int) {
 
 func shortFile(file string, flag int) string {
 	sep := "/"
-	if (flag & Lmodule) != 0 {
-		sep = "/src/"
-	}
 	pos := strings.LastIndex(file, sep)
 	if pos != -1 {
 		return file[pos+5:]
@@ -180,7 +176,7 @@ func (l *Logger) Output(reqID string, lvl int, calldepth int, s string) error {
 	var line int
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.flag&(Lshortfile|Llongfile|Lmodule) != 0 {
+	if l.flag&(Lshortfile|Llongfile) != 0 {
 		// release lock while getting caller info - it's expensive.
 		l.mu.Unlock()
 		var ok bool

--- a/log/logext.go
+++ b/log/logext.go
@@ -119,7 +119,7 @@ func trimModPrefix(file string) string {
 	return strings.TrimPrefix(file, modulePath+"/")
 }
 
-// formatFile returns last two path elements if file path is absolute path,
+// formatFile returns last N path elements if file path is absolute path,
 // otherwise return the path which relative to the module path.
 func formatFile(file string, lastN int) string {
 	if !filepath.IsAbs(file) {

--- a/log/logext_test.go
+++ b/log/logext_test.go
@@ -1,0 +1,25 @@
+package log
+
+import (
+	"testing"
+)
+
+func TestFormatFile(t *testing.T) {
+	tcs := []struct {
+		file     string
+		lastN    int
+		expected string
+	}{
+		{"github.com/qiniu/log.v1/logext_test.go", 1, "github.com/qiniu/log.v1/logext_test.go"},
+		{"/qbox/github.com/qiniu/log.v1/logext_test.go", 2, "log.v1/logext_test.go"},
+		{"/qbox/github.com/qiniu/log.v1/logext_test.go", 1, "logext_test.go"},
+		{"logext_test.go", 2, "logext_test.go"},
+		{"/logext_test.go", 2, "/logext_test.go"},
+		{"/a/logext_test.go", 2, "a/logext_test.go"},
+	}
+	for _, tc := range tcs {
+		if actual := formatFile(tc.file, tc.lastN); actual != tc.expected {
+			t.Errorf("formatFile(%v, %v) = %v, expected %v", tc.file, tc.lastN, actual, tc.expected)
+		}
+	}
+}

--- a/log/logext_test.go
+++ b/log/logext_test.go
@@ -4,6 +4,9 @@
 package log
 
 import (
+	"bytes"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -24,5 +27,52 @@ func TestFormatFile(t *testing.T) {
 		if actual := formatFile(tc.file, tc.lastN); actual != tc.expected {
 			t.Errorf("formatFile(%v, %v) = %v, expected %v", tc.file, tc.lastN, actual, tc.expected)
 		}
+	}
+}
+
+func TestLog(t *testing.T) {
+	out := bytes.Buffer{}
+	logx := New(&out, Std.Prefix(), Std.Flags())
+	logx.Info("hello")
+	result := out.String()
+
+	// check time prefix
+	actual := result[:26]
+	if !regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}.\d{6}$`).MatchString(actual) {
+		t.Errorf("time prefix of logx.Info() = %v, expected %v ", actual, "yyyy/mm/dd hh:mm:ss.xxxxxx")
+	}
+
+	// check level prefix
+	actual = result[27:33]
+	if actual != "[INFO]" {
+		t.Errorf("level prefix of logx.Info() = %v, expected %v ", actual, "[INFO]")
+	}
+
+	// check file prefix
+	actual = result[34:53]
+	if actual != "log/logext_test.go:" {
+		t.Errorf("file prefix of logx.Info() = %v, expected %v ", actual, " logext_test.go: ")
+	}
+}
+
+func TestLongFile(t *testing.T) {
+	out := bytes.Buffer{}
+	logx := New(&out, Std.Prefix(), Llongfile|Llevel|LstdFlags)
+	logx.Info("hello")
+	result := out.String()
+	suffix := "x/log/logext_test.go:61: hello\n"
+	if !strings.HasSuffix(result, suffix) {
+		t.Errorf("Llongfile mode, logx.Info() = %v, which expected to include suffix %v ", result, suffix)
+	}
+}
+
+func TestShortFile(t *testing.T) {
+	out := bytes.Buffer{}
+	logx := New(&out, Std.Prefix(), Lshortfile|Llevel|LstdFlags)
+	logx.Info("hello")
+	result := out.String()
+	suffix := "logext_test.go:72: hello\n"
+	if !strings.HasSuffix(result, suffix) {
+		t.Errorf("Lshortfile mode, logx.Info() = %v, which expected to include suffix %v ", result, suffix)
 	}
 }

--- a/log/logext_test.go
+++ b/log/logext_test.go
@@ -1,3 +1,6 @@
+//go:build unix
+// +build unix
+
 package log
 
 import (

--- a/log/logext_windows_test.go
+++ b/log/logext_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+// +build windows
+
+package log
+
+import (
+	"testing"
+)
+
+func TestFormatFile(t *testing.T) {
+	tcs := []struct {
+		file     string
+		lastN    int
+		expected string
+	}{
+		{"C:/log.v1/logext_test.go", 1, "logext_test.go"},
+		{"C:/log.v1/logext_test.go", 2, "log.v1/logext_test.go"},
+		{"github.com/log.v1/logext_test.go", 2, "github.com/log.v1/logext_test.go"},
+	}
+	for _, tc := range tcs {
+		if actual := formatFile(tc.file, tc.lastN); actual != tc.expected {
+			t.Errorf("formatFile(%v, %v) = %v, expected %v", tc.file, tc.lastN, actual, tc.expected)
+		}
+	}
+}

--- a/xlog/xlog.go
+++ b/xlog/xlog.go
@@ -18,7 +18,6 @@ const (
 	Lmicroseconds = log.Lmicroseconds
 	Llongfile     = log.Llongfile
 	Lshortfile    = log.Lshortfile
-	Lmodule       = log.Lmodule
 	Llevel        = log.Llevel
 	LstdFlags     = log.LstdFlags
 	Ldefault      = log.Ldefault


### PR DESCRIPTION
This PR mainly focus: 

- Remove the Lmodule model, which appears to be adapted to the old Go path style. Currently, it is causing a bug where the entire file path is printed even when the Lshortfile option is used if the code path does not include "src". 
- Introduce the Lintermediatefile model and set it as the default option for `Std` Logger.

Now, when using the Std logger, the output prefix will look like the following, which includes the last two path elements of the file. This change aims to make it more IDE-friendly. 
```
2023/11/29 15:35:29.223563 [INFO] log/logext_test.go:81: hello world
``` 
Additionally, if the compilation includes the `-trimpath` parameter, the output prefix will exclude the module path prefix, resulting in a cleaner file path display.